### PR TITLE
New patch for vigra: Allow import of RandomForests from read-only hdf5 files.

### DIFF
--- a/patches/vigra-2.patch
+++ b/patches/vigra-2.patch
@@ -1,0 +1,11 @@
+--- include/vigra/random_forest_hdf5_impex.hxx	2013-01-23 11:29:40.000000000 -0500
++++ include/vigra/random_forest_hdf5_impex.hxx_patched	2013-01-23 11:29:55.000000000 -0500
+@@ -296,7 +296,7 @@
+                     const std::string & filename, 
+                     const std::string & pathname = "")
+ {
+-    HDF5File h5context(filename, HDF5File::Open);
++    HDF5File h5context(filename, HDF5File::OpenReadOnly);
+     return rf_import_HDF5(rf, h5context, pathname);
+ }
+ 

--- a/vigra.cmake
+++ b/vigra.cmake
@@ -46,17 +46,16 @@ external_source (vigra
 #    vigra-flyem-1.7.1.tar.gz
 #    7325a6fed78383807fd553fc5ee30190)
 
-if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+set (vigra_PATCH ${BUILDEM_ENV_STRING} ${PATCH_EXE}
     # The vigra 1.9.0 release assumes all mac builds are "Framework" builds.
     # This patch allows us to build vigra against non-Framework builds, too.
+    # (The mac build patch has no effect for non-Mac platforms.)
     # NOTE: This issue will be fixed in vigra-HEAD on github soon, so this patch 
     #       won't be necessary soon.  The patch may fail to apply when you upgrade
     #       vigra beyond 1.9.0.
-    set (vigra_PATCH ${BUILDEM_ENV_STRING} ${PATCH_EXE}
-        ${vigra_SRC_DIR}/config/FindVIGRANUMPY_DEPENDENCIES.cmake ${PATCH_DIR}/vigra.patch )
-else()
-    set (vigra_PATCH "")
-endif()
+    ${vigra_SRC_DIR}/config/FindVIGRANUMPY_DEPENDENCIES.cmake ${PATCH_DIR}/vigra.patch 
+    # Add second patch to fix RandomForest importing from hdf5 (should open in read-only mode)
+    ${vigra_SRC_DIR}/include/vigra/random_forest_hdf5_impex.hxx ${PATCH_DIR}/vigra-2.patch )
 
 message ("Installing ${vigra_NAME} into FlyEM build area: ${BUILDEM_DIR} ...")
 ExternalProject_Add(${vigra_NAME}


### PR DESCRIPTION
I tested this patch.  Without the patch, importing a random forest from a read-only hdf5 file raises an exception.  After the patch, I get no errors.

I've already opened a pull request for this fix on vigra.
