### PR TITLE
added missing DEPENDS specs for qt4

### DIFF
--- a/qt4.cmake
+++ b/qt4.cmake
@@ -40,7 +40,7 @@ endif()
 # (This builds everything that ilastik needs.)
 
 ExternalProject_Add(${qt4_NAME}
-    DEPENDS             ${freetype2_NAME}
+    DEPENDS             ${freetype2_NAME} ${zlib_NAME} ${libpng_NAME} ${libjpeg_NAME} ${libtiff_NAME}
     PREFIX              ${BUILDEM_DIR}
     URL                 ${qt4_URL}
     URL_MD5             ${qt4_MD5}


### PR DESCRIPTION
In qt4.cmake, Qt is configured to use pre-installed shared libraries for tiff, png and jpeg to prevent qt from compiling private versions of these libs. The idea is that the libs shall be taken from $BUILDEM_DIR/lib, **not** from the OS. However, the library packages were not mentioned in the DEPENDS clause of ExternalProject_Add(), and qt happened to be compiled before tiff (maybe for alphabetic reasons), causing the build to fail. Jens worked around this failure by installing libtiff-dev, but this led to a shared library conflict at execution time, causing a strange crash.

As a side note: this happened to me several times because the dependency specification in buildem is redundant. I added issue https://github.com/janelia-flyem/buildem/issues/24 to address this problem.
